### PR TITLE
fix: C-Next v0.1.53 compatibility

### DIFF
--- a/include/Display/ByteUtils.h
+++ b/include/Display/ByteUtils.h
@@ -24,9 +24,6 @@ uint8_t ByteUtils_byte0(uint32_t value);
 uint8_t ByteUtils_byte1(uint32_t value);
 uint8_t ByteUtils_byte2(uint32_t value);
 uint8_t ByteUtils_byte3(uint32_t value);
-bool ByteUtils_isBitSet(uint8_t value, uint8_t bit);
-uint8_t ByteUtils_setBit(uint8_t value, uint8_t bit);
-uint8_t ByteUtils_clearBit(uint8_t value, uint8_t bit);
 uint8_t ByteUtils_clampU8(uint8_t value, uint8_t minVal, uint8_t maxVal);
 uint16_t ByteUtils_clampU16(uint16_t value, uint16_t minVal, uint16_t maxVal);
 

--- a/include/Domain/CommandHandler.h
+++ b/include/Domain/CommandHandler.h
@@ -51,7 +51,7 @@ uint8_t CommandHandler_applyNtcPreset(AppConfig& cfg, uint8_t input, uint8_t pre
 uint8_t CommandHandler_applyPressurePreset(AppConfig& cfg, uint8_t input, uint8_t preset);
 uint8_t CommandHandler_setNtcParam(AppConfig& cfg, uint8_t input, uint8_t param, float value);
 uint8_t CommandHandler_save(const AppConfig& cfg);
-uint8_t CommandHandler_reset(const AppConfig& cfg);
+uint8_t CommandHandler_reset(AppConfig& cfg);
 uint8_t CommandHandler_querySpnCounts(const AppConfig& cfg, TQueryResult& out);
 uint8_t CommandHandler_queryFullConfig(const AppConfig& cfg, TQueryResult& out);
 uint8_t CommandHandler_queryTempSpns(const AppConfig& cfg, uint8_t subQuery, TQueryResult& out);

--- a/include/Domain/SerialCommandHandler.h
+++ b/include/Domain/SerialCommandHandler.h
@@ -36,7 +36,7 @@ extern uint8_t cmdIndex;
 
 /* Function prototypes */
 void SerialCommandHandler_initialize(void);
-void SerialCommandHandler_update(const AppConfig& config, const AppData& appData);
+void SerialCommandHandler_update(AppConfig& config, const AppData& appData);
 
 #ifdef __cplusplus
 }

--- a/src/Data/ConfigStorage.cpp
+++ b/src/Data/ConfigStorage.cpp
@@ -31,37 +31,37 @@ bool ConfigStorage_validateConfig(const AppConfig& config) {
 }
 
 void ConfigStorage_loadDefaults(AppConfig& config) {
-    config->magic = CONFIG_MAGIC;
-    config->version = CONFIG_VERSION;
-    config->j1939SourceAddress = 149;
+    config.magic = CONFIG_MAGIC;
+    config.version = CONFIG_VERSION;
+    config.j1939SourceAddress = 149;
     for (uint32_t i = 0; i < TEMP_INPUT_COUNT; i += 1) {
-        config->tempInputs[i].assignedSpn = 0;
-        config->tempInputs[i].coeffA = AEM_TEMP_COEFF_A;
-        config->tempInputs[i].coeffB = AEM_TEMP_COEFF_B;
-        config->tempInputs[i].coeffC = AEM_TEMP_COEFF_C;
-        config->tempInputs[i].resistorValue = AEM_TEMP_RESISTOR;
+        config.tempInputs[i].assignedSpn = 0;
+        config.tempInputs[i].coeffA = AEM_TEMP_COEFF_A;
+        config.tempInputs[i].coeffB = AEM_TEMP_COEFF_B;
+        config.tempInputs[i].coeffC = AEM_TEMP_COEFF_C;
+        config.tempInputs[i].resistorValue = AEM_TEMP_RESISTOR;
     }
     for (uint32_t i = 0; i < PRESSURE_INPUT_COUNT; i += 1) {
-        config->pressureInputs[i].assignedSpn = 0;
-        config->pressureInputs[i].maxPressure = 100;
-        config->pressureInputs[i].pressureType = EPressureType_PRESSURE_TYPE_PSIG;
-        config->pressureInputs[i].reserved = 0;
+        config.pressureInputs[i].assignedSpn = 0;
+        config.pressureInputs[i].maxPressure = 100;
+        config.pressureInputs[i].pressureType = EPressureType_PRESSURE_TYPE_PSIG;
+        config.pressureInputs[i].reserved = 0;
     }
-    config->egtEnabled = false;
-    config->thermocoupleType = EThermocoupleType_TC_TYPE_K;
-    config->bme280Enabled = false;
-    config->checksum = Crc32_calculateChecksum(config);
+    config.egtEnabled = false;
+    config.thermocoupleType = EThermocoupleType_TC_TYPE_K;
+    config.bme280Enabled = false;
+    config.checksum = Crc32_calculateChecksum(config);
 }
 
 bool ConfigStorage_saveConfig(const AppConfig& config) {
-    AppConfig configToSave = (*config);
+    AppConfig configToSave = config;
     configToSave.checksum = Crc32_calculateChecksum(config);
     EEPROM.put(0, configToSave);
     return true;
 }
 
 bool ConfigStorage_loadConfig(AppConfig& config) {
-    EEPROM.get(0, (*config));
+    EEPROM.get(0, config);
     bool isValid = ConfigStorage_validateConfig(config);
     if (!isValid) {
         ConfigStorage_loadDefaults(config);

--- a/src/Data/MAX31856Manager.cpp
+++ b/src/Data/MAX31856Manager.cpp
@@ -67,7 +67,7 @@ static void MAX31856Manager_readResult(void) {
     MAX31856Manager_conversionStarted = false;
 }
 
-void MAX31856Manager_initialize(const AppConfig config) {
+void MAX31856Manager_initialize(const AppConfig& config) {
     MAX31856Manager_enabled = config.egtEnabled;
     if (!MAX31856Manager_enabled) {
         Serial.println("MAX31856 disabled in config");

--- a/src/Display/ByteUtils.cnx
+++ b/src/Display/ByteUtils.cnx
@@ -69,26 +69,6 @@ scope ByteUtils {
         return value[24,8];
     }
 
-    // Check if bit is set in byte
-    public bool isBitSet(u8 value, u8 bit) {
-        if (bit > 7) { return false; }
-        return value[bit,1] != 0;
-    }
-
-    // Set bit in byte (returns new value)
-    public u8 setBit(u8 value, u8 bit) {
-        if (bit > 7) { return value; }
-        value[bit,1] <- 1;
-        return value;
-    }
-
-    // Clear bit in byte (returns new value)
-    public u8 clearBit(u8 value, u8 bit) {
-        if (bit > 7) { return value; }
-        value[bit,1] <- 0;
-        return value;
-    }
-
     // Clamp value to range
     public u8 clampU8(u8 value, u8 minVal, u8 maxVal) {
         if (value < minVal) { return minVal; }

--- a/src/Display/ByteUtils.cpp
+++ b/src/Display/ByteUtils.cpp
@@ -6,7 +6,6 @@
 #include "ByteUtils.h"
 
 #include <stdint.h>
-#include <stdbool.h>
 
 // Byte Utility Functions
 // Common byte manipulation operations for embedded systems
@@ -67,29 +66,6 @@ uint8_t ByteUtils_byte2(uint32_t value) {
 
 uint8_t ByteUtils_byte3(uint32_t value) {
     return ((value >> 24) & 0xFFU);
-}
-
-bool ByteUtils_isBitSet(uint8_t value, uint8_t bit) {
-    if (bit > 7) {
-        return false;
-    }
-    return ((value >> bit) & ((1U << 1) - 1)) != 0;
-}
-
-uint8_t ByteUtils_setBit(uint8_t value, uint8_t bit) {
-    if (bit > 7) {
-        return value;
-    }
-    value = (value & ~(((1U << 1) - 1) << bit)) | ((1 & ((1U << 1) - 1)) << bit);
-    return value;
-}
-
-uint8_t ByteUtils_clearBit(uint8_t value, uint8_t bit) {
-    if (bit > 7) {
-        return value;
-    }
-    value = (value & ~(((1U << 1) - 1) << bit)) | ((0 & ((1U << 1) - 1)) << bit);
-    return value;
 }
 
 uint8_t ByteUtils_clampU8(uint8_t value, uint8_t minVal, uint8_t maxVal) {

--- a/src/Display/Crc32.cpp
+++ b/src/Display/Crc32.cpp
@@ -29,11 +29,11 @@ static uint32_t Crc32_crcByte(uint32_t crc, uint8_t byte) {
 static uint32_t Crc32_crcFloat(uint32_t& crc, float value) {
     char buf[5] = "";
     memcpy(&buf[0], &value, 4);
-    (*crc) = Crc32_crcByte((*crc), buf[0]);
-    (*crc) = Crc32_crcByte((*crc), buf[1]);
-    (*crc) = Crc32_crcByte((*crc), buf[2]);
-    (*crc) = Crc32_crcByte((*crc), buf[3]);
-    return (*crc);
+    crc = Crc32_crcByte(crc, buf[0]);
+    crc = Crc32_crcByte(crc, buf[1]);
+    crc = Crc32_crcByte(crc, buf[2]);
+    crc = Crc32_crcByte(crc, buf[3]);
+    return crc;
 }
 
 uint32_t Crc32_calculateChecksum(const AppConfig& config) {

--- a/src/Display/J1939Bus.cnx
+++ b/src/Display/J1939Bus.cnx
@@ -31,14 +31,14 @@ scope J1939Bus {
     }
 
     // Fill buffer with 0xFF (unused bytes)
-    void fillBuffer(u8 buf) {
+    void fillBuffer(u8 buf[8]) {
         for (u8 i <- 0; i < 8; i +<- 1) {
             buf[i] <- 0xFF;
         }
     }
 
     // Helper to send a CAN message with priority 6
-    void sendMessage(u16 pgn, const u8 buf) {
+    void sendMessage(u16 pgn, const u8 buf[8]) {
         CAN_message_t msg;
         msg.flags.extended <- 1;
         msg.id <- this.buildCanId(pgn, 6, this.config.j1939SourceAddress);

--- a/src/Display/J1939Bus.cpp
+++ b/src/Display/J1939Bus.cpp
@@ -31,19 +31,19 @@ static uint32_t J1939Bus_buildCanId(uint16_t pgn, uint8_t priority, uint8_t sour
     return id;
 }
 
-static void J1939Bus_fillBuffer(uint8_t buf) {
+static void J1939Bus_fillBuffer(uint8_t buf[8]) {
     for (uint8_t i = 0; i < 8; i += 1) {
-        buf = (buf & ~(1 << i)) | ((0xFF ? 1 : 0) << i);
+        buf[i] = 0xFF;
     }
 }
 
-static void J1939Bus_sendMessage(uint16_t pgn, const uint8_t buf) {
+static void J1939Bus_sendMessage(uint16_t pgn, const uint8_t buf[8]) {
     CAN_message_t msg = {};
     msg.flags.extended = 1;
     msg.id = J1939Bus_buildCanId(pgn, 6, J1939Bus_config.j1939SourceAddress);
     msg.len = 8;
     for (uint8_t i = 0; i < 8; i += 1) {
-        msg.buf[i] = ((buf >> i) & 1);
+        msg.buf[i] = buf[i];
     }
     J1939Bus_canBus.write(msg);
 }
@@ -225,13 +225,13 @@ static void J1939Bus_sniffDataPrivate(const CAN_message_t& msg) {
         return;
     }
     if (message.pgn == 59904) {
-        J1939Bus_canBus.write((*msg));
+        J1939Bus_canBus.write(msg);
     }
 }
 
 void J1939Bus_initialize(const AppData& currentData, const AppConfig& cfg) {
-    J1939Bus_appData = (*currentData);
-    J1939Bus_config = (*cfg);
+    J1939Bus_appData = currentData;
+    J1939Bus_config = cfg;
     Serial.println("J1939 Bus initializing");
     J1939Bus_canBus.begin();
     J1939Bus_canBus.setBaudRate(250000);

--- a/src/Domain/SensorProcessor.cpp
+++ b/src/Domain/SensorProcessor.cpp
@@ -24,7 +24,7 @@ static AppConfig SensorProcessor_config = {0};
 static bool SensorProcessor_initialized = false;
 
 void SensorProcessor_initialize(const AppConfig& cfg) {
-    SensorProcessor_config = (*cfg);
+    SensorProcessor_config = cfg;
     SensorProcessor_initialized = true;
 }
 
@@ -38,75 +38,75 @@ static float SensorProcessor_getAtmosphericPressurekPa(const AppData& appData) {
 static void SensorProcessor_updateAppDataForSpn(AppData& appData, uint16_t spn, float value) {
     switch (spn) {
         case 175: {
-            appData->oilTemperatureC = value;
+            appData.oilTemperatureC = value;
             break;
         }
         case 110: {
-            appData->coolantTemperatureC = value;
+            appData.coolantTemperatureC = value;
             break;
         }
         case 1637: {
-            appData->coolantTemperatureC = value;
+            appData.coolantTemperatureC = value;
             break;
         }
         case 174: {
-            appData->fuelTemperatureC = value;
+            appData.fuelTemperatureC = value;
             break;
         }
         case 105: {
-            appData->boostTemperatureC = value;
+            appData.boostTemperatureC = value;
             break;
         }
         case 1363: {
-            appData->boostTemperatureC = value;
+            appData.boostTemperatureC = value;
             break;
         }
         case 1131: {
-            appData->cacInletTemperatureC = value;
+            appData.cacInletTemperatureC = value;
             break;
         }
         case 1132: {
-            appData->transferPipeTemperatureC = value;
+            appData.transferPipeTemperatureC = value;
             break;
         }
         case 1133: {
-            appData->airInletTemperatureC = value;
+            appData.airInletTemperatureC = value;
             break;
         }
         case 172: {
-            appData->airInletTemperatureC = value;
+            appData.airInletTemperatureC = value;
             break;
         }
         case 441: {
-            appData->engineBayTemperatureC = value;
+            appData.engineBayTemperatureC = value;
             break;
         }
         case 100: {
-            appData->oilPressurekPa = value;
+            appData.oilPressurekPa = value;
             break;
         }
         case 109: {
-            appData->coolantPressurekPa = value;
+            appData.coolantPressurekPa = value;
             break;
         }
         case 94: {
-            appData->fuelPressurekPa = value;
+            appData.fuelPressurekPa = value;
             break;
         }
         case 102: {
-            appData->boostPressurekPa = value;
+            appData.boostPressurekPa = value;
             break;
         }
         case 106: {
-            appData->airInletPressurekPa = value;
+            appData.airInletPressurekPa = value;
             break;
         }
         case 1127: {
-            appData->cacInletPressurekPa = value;
+            appData.cacInletPressurekPa = value;
             break;
         }
         case 1128: {
-            appData->transferPipePressurekPa = value;
+            appData.transferPipePressurekPa = value;
             break;
         }
         default: {
@@ -146,16 +146,16 @@ static void SensorProcessor_processPressureInputs(AppData& appData) {
 static void SensorProcessor_processEgt(AppData& appData) {
     bool egtReady = MAX31856Manager_isEnabled();
     if (SensorProcessor_config.egtEnabled && egtReady) {
-        appData->egtTemperatureC = MAX31856Manager_getTemperatureC();
+        appData.egtTemperatureC = MAX31856Manager_getTemperatureC();
     }
 }
 
 static void SensorProcessor_processBme280(AppData& appData) {
     bool bmeReady = BME280Manager_isEnabled();
     if (SensorProcessor_config.bme280Enabled && bmeReady) {
-        appData->ambientTemperatureC = BME280Manager_getTemperatureC();
-        appData->humidity = BME280Manager_getHumidity();
-        appData->absoluteBarometricpressurekPa = BME280Manager_getPressurekPa();
+        appData.ambientTemperatureC = BME280Manager_getTemperatureC();
+        appData.humidity = BME280Manager_getHumidity();
+        appData.absoluteBarometricpressurekPa = BME280Manager_getPressurekPa();
     }
 }
 

--- a/src/Domain/SerialCommandHandler.cpp
+++ b/src/Domain/SerialCommandHandler.cpp
@@ -190,7 +190,7 @@ static void SerialCommandHandler_reportFaults(void) {
     }
 }
 
-static void SerialCommandHandler_handleEnableSpn(const AppConfig& config) {
+static void SerialCommandHandler_handleEnableSpn(AppConfig& config) {
     if (parsed.count < 4) {
         Serial.println("ERR,2,Usage: 1,spnHi,spnLo,enable[,input]");
         return;
@@ -256,7 +256,7 @@ static void SerialCommandHandler_handleEnableSpn(const AppConfig& config) {
     }
 }
 
-static void SerialCommandHandler_handleSetPressureRange(const AppConfig& config) {
+static void SerialCommandHandler_handleSetPressureRange(AppConfig& config) {
     if (parsed.count < 4) {
         Serial.println("ERR,2,Usage: 3,input,valueHi,valueLo (use preset cmd 9)");
         return;
@@ -276,7 +276,7 @@ static void SerialCommandHandler_handleSetPressureRange(const AppConfig& config)
     Serial.println(maxPressure);
 }
 
-static void SerialCommandHandler_handleSetTcType(const AppConfig& config) {
+static void SerialCommandHandler_handleSetTcType(AppConfig& config) {
     if (parsed.count < 2) {
         Serial.println("ERR,2,Usage: 4,type (0-7)");
         return;
@@ -373,13 +373,13 @@ static void SerialCommandHandler_handleSave(const AppConfig& config) {
     }
 }
 
-static void SerialCommandHandler_handleReset(const AppConfig& config) {
+static void SerialCommandHandler_handleReset(AppConfig& config) {
     Serial.println("Resetting to defaults...");
     CommandHandler_reset(config);
     Serial.println("OK,Use '6' to save");
 }
 
-static void SerialCommandHandler_handleNtcPreset(const AppConfig& config) {
+static void SerialCommandHandler_handleNtcPreset(AppConfig& config) {
     if (parsed.count < 3) {
         Serial.println("ERR,2,Usage: 8,input,preset (0=AEM,1=Bosch,2=GM)");
         return;
@@ -403,7 +403,7 @@ static void SerialCommandHandler_handleNtcPreset(const AppConfig& config) {
     Serial.println(" preset");
 }
 
-static void SerialCommandHandler_handlePressurePreset(const AppConfig& config) {
+static void SerialCommandHandler_handlePressurePreset(AppConfig& config) {
     if (parsed.count < 3) {
         Serial.println("ERR,2,Usage: 9,input,preset (0-15=bar, 20-30=PSIG)");
         return;
@@ -572,7 +572,7 @@ static void SerialCommandHandler_handleDumpEeprom(void) {
     Serial.println("END");
 }
 
-static void SerialCommandHandler_processCommand(const AppConfig& config, const AppData& appData) {
+static void SerialCommandHandler_processCommand(AppConfig& config, const AppData& appData) {
     uint32_t len = strlen(cmdBuffer);
     if (len == 0) {
         return;
@@ -639,7 +639,7 @@ void SerialCommandHandler_initialize(void) {
     Serial.println("Commands: 1,spnHi,spnLo,en,input | 5,query | 6 | 7 | 8,in,preset | 9,in,preset");
 }
 
-void SerialCommandHandler_update(const AppConfig& config, const AppData& appData) {
+void SerialCommandHandler_update(AppConfig& config, const AppData& appData) {
     int32_t available = Serial.available();
     while (available > 0) {
         int32_t readResult = Serial.read();


### PR DESCRIPTION
## Summary
- Remove unused `isBitSet`, `setBit`, `clearBit` functions from ByteUtils (C-Next now enforces compile-time constant slice offsets)
- Fix array parameter declarations in J1939Bus (`u8 buf` → `u8 buf[8]`)
- Regenerate all C-Next output with transpiler v0.1.53

## Test plan
- [x] Build passes with `pio run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)